### PR TITLE
Bap 9623 : modify oro-redis bundle configuration

### DIFF
--- a/DependencyInjection/OroRedisConfigExtension.php
+++ b/DependencyInjection/OroRedisConfigExtension.php
@@ -25,7 +25,7 @@ class OroRedisConfigExtension extends Extension implements PrependExtensionInter
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        if ($container->hasParameter('redis_dsn')) {
+        if ($container->hasParameter('redis_dsn_cache') && $container->hasParameter('redis_dsn_session')) {
             $loader = new Loader\YamlFileLoader($container, $this->fileLocator);
             $loader->load('services.yml');
         }
@@ -34,7 +34,7 @@ class OroRedisConfigExtension extends Extension implements PrependExtensionInter
     /** {@inheritdoc} */
     public function prepend(ContainerBuilder $container)
     {
-        if ($container->hasParameter('redis_dsn')) {
+        if ($container->hasParameter('redis_dsn_cache') && $container->hasParameter('redis_dsn_session')) {
             $configs = Yaml::parse($this->fileLocator->locate('redis.yml'));
         } else {
             $configs = Yaml::parse($this->fileLocator->locate('redis_dummy.yml'));

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ From project root need to run
 ### Configuration
 In parameters.yml need to add redis config section
 ``` yaml
-    redis_dsn: "redis://password@host:port"
+    redis_dsn_cache: "redis://password@host:port/db"
+    redis_dsn_session: "redis://password@host:port/db"
 ```
 
 After this need to remove cache.

--- a/Resources/config/redis.yml
+++ b/Resources/config/redis.yml
@@ -7,15 +7,15 @@ snc_redis:
         default:
             type: predis
             alias: default
-            dsn: %redis_dsn%/1
+            dsn: %redis_dsn_cache%
         doctrine:
             type: predis
             alias: doctrine
-            dsn: %redis_dsn%/2
+            dsn: %redis_dsn_cache%
         session:
             type: predis
             alias: session
-            dsn: %redis_dsn%/3
+            dsn: %redis_dsn_session%
     doctrine: # use Redis caching for Doctrine
         metadata_cache:
             client: doctrine


### PR DESCRIPTION
- moved to independent parameter redis_dsn_cache and redis_dsn_session
