### PR TITLE
No need to share annotations

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -56,8 +56,10 @@ services:
         calls:
             - [ setNamespace, [ 'oro_nonces_cache' ] ]
 
-    oro.cache.annotations:
+    oro_cache.annotations:
+        parent: doctrine_cache.abstract.file_system
         public: false
-        parent: oro.cache.abstract
+        arguments:
+            - '%kernel.cache_dir%/annotations'
         calls:
             - [ setNamespace, [ 'oro_annotations_cache' ] ]


### PR DESCRIPTION
They are static, but cause a lot of IO operations to Redis