### PR TITLE
Remove hard coded session handler

### DIFF
--- a/Resources/config/redis.yml
+++ b/Resources/config/redis.yml
@@ -1,8 +1,6 @@
 framework:
     annotations:
         cache: oro.cache.annotations
-    session:
-        handler_id: snc_redis.session.handler
 doctrine:
     orm:
         entity_managers:

--- a/Resources/config/redis.yml
+++ b/Resources/config/redis.yml
@@ -42,7 +42,7 @@ snc_redis:
     session:  # configure sessions
         client: session
         prefix: session
-        use_as_default: true
+        use_as_default: false
 
 jms_serializer:
     metadata:


### PR DESCRIPTION
In case if user wants to use Redis as cache storage but don't for session storage we should be able setup it through parameters.yml. But due to hard coded config we can't.